### PR TITLE
rails5 make checker and object_resource optional for an action

### DIFF
--- a/app/models/four_eyes/action.rb
+++ b/app/models/four_eyes/action.rb
@@ -3,9 +3,9 @@ module FourEyes
     validates :action_type, :maker_id, :status, presence: true
 
     belongs_to :maker, polymorphic: true
-    belongs_to :checker, polymorphic: true
+    belongs_to :checker, polymorphic: true, optional: true
     belongs_to :assignable, polymorphic: true
-    belongs_to :object_resource, polymorphic: true
+    belongs_to :object_resource, polymorphic: true, optional: true
 
     def self.between_times(start_time, end_time)
       Action.where('created_at >= ? AND created_at < ?', start_time, end_time)


### PR DESCRIPTION
it's not possible to create external mpesa wallets and payments actions because `FourEyes::Action`s belong to `checker`, `assignable,` and `object_resource`, and there's no way to assign a `checker` and `object_resource` beforehand.

a `checker` can be assigned when creating the object, and an `object_resource` can be assigned after creating the object, after the action has been approved, although that may not be necessary at that point.